### PR TITLE
Add developer guide and readme

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^doc$
 ^Meta$
 ^.travis.yml$
+^CONTRIBUTING\.md$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ Set the local repository to track the GitHub repository too, and create a
 branch following GitHub's master:
 
     $ git remote add origin https://github.com/davidrusi/mombf.git
+    $ git fetch origin
     $ git checkout master
 
 Finally, checkout and create a feature branch to work on. It is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# `mombf` contributor guide
+
+You can contribute to `mombf` by raising issues about bugs, suggest
+improvements to the documentation and vignettes, etc. You can also contribute
+by sending code directly to `mombf`, however, before sending a Pull Request
+to `mombf` check out the Issue tracker to see
+possible contributions. If you would like to add a new feature, please
+submit an issue first with your feature request to see if it fits with
+what we have in mind.
+
+To submit a Pull Request, fork `mombf`'s GitHub repository, fix some bug, improve the docs...
+and submit a Pull Request on GitHub.
+
+# `mombf` developer guide
+
+## Get Started
+
+`mombf` uses both GitHub and R-forge. GitHub is used to track
+changes, issues and handle pull requests, and R-forge is used to
+compile system specific binaries and interact with CRAN. In order
+to create a folder tracking both platforms, start by creating a
+repository from R-forge:
+
+    $ git svn clone svn+ssh://user@scm.r-forge.r-project.org/svnroot/mombf/pkg/mombf/
+
+This will create a folder called `mombf` containing the R package. If `git
+svn` does not work, try installing `git-svn`, in Debian/Ubuntu this can be
+done with `sudo apt install git-svn`. Check that the output of `ls mombf` is
+similar to:
+
+    ChangeLog  CONTRIBUTING.md  data  DESCRIPTION  INDEX
+    LICENSE  man  NAMESPACE  R  src  vignettes
+
+Enter into the `mombf` folder and check that `.git/config` contains something
+similar to:
+
+    [svn-remote "<rforge/svn>"]
+        url = path/or/url/to/svn/repository
+        fetch = :refs/remotes/<r-forge/git>-svn
+
+Rename the master branch:
+
+    $ git branch -m r-forge_local
+
+Set the local repository to track the GitHub repository too, and create a
+branch following GitHub's master:
+
+    $ git remote add origin https://github.com/davidrusi/mombf.git
+    $ git checkout master
+
+Finally, checkout and create a feature branch to work on. It is not
+recommended to work on master.
+
+## Merge GitHub changes back into R-forge
+Once there are enough changes to release a new version of `mombf`, changes in
+GitHub must be merged into R-forge:
+
+    $ git checkout r-forge_local
+    $ git merge master
+    $ git rebase
+
+And finally, push this changes to R-forge:
+
+    $ git svn rebase
+    $ git svn dcommit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,6 @@ GitHub must be merged into R-forge:
 
     $ git checkout r-forge_local
     $ git merge master
-    $ git rebase
 
 And finally, push this changes to R-forge:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-# `mombf` contributor guide
+`mombf` contributor guide
+-------------------------
 
 You can contribute to `mombf` by raising issues about bugs, suggest
 improvements to the documentation and vignettes, etc. You can also contribute
@@ -11,17 +12,39 @@ what we have in mind.
 To submit a Pull Request, fork `mombf`'s GitHub repository, fix some bug, improve the docs...
 and submit a Pull Request on GitHub.
 
-# `mombf` developer guide
+`mombf` developer guide
+-----------------------
+
 This section of the Contributing guide is intended for _developers_
 of `mombf` in the sense that they are expected to release new versions
 of the package, which is done via R-forge. All other contributions can
 be done with GitHub forks and Pull Requests.
 
-## Get Started
-
+## Background
 `mombf` uses both GitHub and R-forge. GitHub is used to track
 changes, issues and handle pull requests, and R-forge is used to
-compile system specific binaries and interact with CRAN. In order
+compile system specific binaries and interact with CRAN. This means that
+there are two _different_ version control systems tracking the _same code_.
+Thus, **it is vital to check the branch you are working on is up to date
+before working**.
+
+The general idea behind this is the following. R-forge uses svn which is
+centralized, therefore, in order to avoid problems with its log, we will
+use GitHub to develop in a distributed way _starting from svn HEAD's_. The
+steps in the development process can then be summarized as follows. New
+features are developed on GitHub, and merged into its master branch (to
+simplify everything, it is recommended to squash merge). Right after merging
+a change into GitHub master, the change is updated to R-forge (which will give
+the new commit a different identifier) and GitHub master branch is eventually
+rebased to R-forge master.
+
+If the changes are developed in R-forge, then before merging anything into
+GitHub master, it should be checked that GitHub master is up to date with
+R-forge.
+
+## Get Started
+
+In order
 to create a folder tracking both platforms, start by creating a
 repository from R-forge:
 
@@ -62,7 +85,19 @@ GitHub must be merged into R-forge:
     $ git checkout r-forge_local
     $ git merge master
 
-And finally, push this changes to R-forge:
+Afterwards, push this changes to R-forge:
 
     $ git svn rebase
     $ git svn dcommit
+
+Finally, rebase GitHub master so that it shares the same tree as R-forge
+repository.
+
+    $ git checkout master
+    $ git rebase r-forge_local
+    $ git push -f
+
+Note that the push of the rebased master to GitHub must be a forced one
+because we are actually updating the commit ids to match the ones in R-forge.
+However, it should also be noted that the code is **not** changed, so there
+should never be merge problems while rebasing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ To submit a Pull Request, fork `mombf`'s GitHub repository, fix some bug, improv
 and submit a Pull Request on GitHub.
 
 # `mombf` developer guide
+This section of the Contributing guide is intended for _developers_
+of `mombf` in the sense that they are expected to release new versions
+of the package, which is done via R-forge. All other contributions can
+be done with GitHub forks and Pull Requests.
 
 ## Get Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ recommended to work on master.
 
 ## Merge GitHub changes back into R-forge
 Once there are enough changes to release a new version of `mombf`, changes in
-GitHub must be merged into R-forge:
+GitHub must be merged into R-forge. After making sure that local master is up
+to date with GitHub master:
 
     $ git checkout r-forge_local
     $ git merge master

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Version: 2.2.5
 Date: 2019-07-18
 Title: Bayesian Model Selection and Averaging for Non-Local and Local Priors
-Author: David Rossell, John D. Cook, Donatello Telesca, P. Roebuck
+Author: David Rossell, John D. Cook, Donatello Telesca, P. Roebuck, Oriol Abril
 Maintainer: David Rossell <rosselldavid@gmail.com>
 Depends: R (>= 2.14.0), methods, mvtnorm, ncvreg, mgcv
 Imports: Rcpp (>= 0.12.16), mclust, survival
@@ -11,7 +11,8 @@ Suggests: parallel
 LinkingTo: Rcpp, RcppArmadillo
 Description: Bayesian model selection and averaging for regression and mixtures for non-local and selected local priors.
 License: GPL (>= 2) | file LICENSE
-URL: http://mombf.r-forge.r-project.org/
+URL: https://github.com/davidrusi/mombf
+BugReports: https://github.com/davidrusi/mombf/issues
 LazyLoad: yes
 Collate: AllClasses.R AllGenerics.R alapl.R bms_ortho.R cox.R derivatives_nlps.R distribs.R dmom.R emomLM.R gam.R greedyGLM.R msPriorSpec.R modelsearch.R modelSelection.R mombf.R normaliwish.R normmix.R nlpMarginal.R pmomLM.R pmomPM.R postMode.R pplProbit.R ppmodel.R rmom.R RcppExports.R testfunction.R zellnerLM.R
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# mombf
+Bayesian model selection and averaging for regression and mixtures for non-local and selected local priors.
+
+## Installation
+
+``` r
+# Install mombf from CRAN
+install.packages("mombf")
+
+# Or the the development version
+# from R-forge
+install.packages("mombf", repos = "http://R-Forge.R-project.org")
+
+# from GitHub:
+# install.packages("devtools")
+devtools::install_github("davidrusi/mombf")
+```
+
+## Quick start
+
+The main Bayesian model selection (BMS) function is `modelSelection`. Bayesian model averaging (BMA)
+is also available for some models,
+mainly linear regression and Normal mixtures.
+Details are in [`mombf`'s vignette](https://cran.r-project.org/web/packages/mombf/vignettes/mombf.pdf),
+here we illustrate quickly how to get posterior model probabilities,
+marginal posterior inclusion probabilities, BMA point estimates and posterior
+intervals for the regression coefficients and predicted outcomes.
+
+```r
+library(mombf)
+set.seed(1234)
+x <- matrix(rnorm(100*3),nrow=100,ncol=3)
+theta <- matrix(c(1,1,0),ncol=1)
+y <- x %*% theta + rnorm(100)
+
+priorCoef <- momprior(tau=0.348)  # Default MOM prior on parameters
+priorDelta <- modelbbprior(1,1)   # Beta-Binomial prior for model space
+fit1 <- modelSelection(y ~ x[,1]+x[,2]+x[,3], priorCoef=priorCoef, priorDelta=priorDelta)
+# Output
+# Enumerating models...
+# Computing posterior probabilities................ Done.
+```
+
+from here, we can also get the posterior model probabilities:
+
+```r
+postProb(fit1)
+# Output
+#    modelid family           pp
+# 7      2,3 normal 9.854873e-01
+# 8    2,3,4 normal 7.597369e-03
+# 15   1,2,3 normal 6.771575e-03
+# 16 1,2,3,4 normal 1.437990e-04
+# 3        3 normal 3.240602e-17
+# 5        2 normal 7.292230e-18
+# 4      3,4 normal 2.150174e-19
+# 11     1,3 normal 9.892869e-20
+# 6      2,4 normal 5.615517e-20
+# 13     1,2 normal 2.226164e-20
+# 12   1,3,4 normal 1.477780e-21
+# 14   1,2,4 normal 3.859388e-22
+# 1          normal 2.409908e-25
+# 2        4 normal 1.300748e-27
+# 9        1 normal 2.757778e-28
+# 10     1,4 normal 3.971521e-30
+```
+
+also the BMA estimates, 95% intervals, marginal posterior probability
+
+```r
+coef(fit1)
+# Output
+#              estimate        2.5%      97.5%      margpp
+# (Intercept) 0.007230966 -0.02624289 0.04085951 0.006915374
+# x[, 1]      1.134700387  0.93487948 1.33599873 1.000000000
+# x[, 2]      1.135810652  0.94075622 1.33621298 1.000000000
+# x[, 3]      0.000263446  0.00000000 0.00000000 0.007741168
+# phi         1.100749637  0.83969879 1.44198567 1.000000000
+```
+
+and BMA predictions for y, 95% intervals
+
+```r
+ypred <- predict(fit1)
+head(ypred)
+# Output
+#         mean       2.5%       97.5%
+# 1 -0.8936883 -1.1165154 -0.67003262
+# 2 -0.2162846 -0.3509188 -0.08331286
+# 3  1.3152329  1.0673711  1.56348261
+# 4 -3.2299241 -3.6826696 -2.77728625
+# 5 -0.4431820 -0.6501280 -0.23919345
+# 6  0.7727824  0.6348189  0.90977798
+cor(y, ypred[,1])
+# Output
+#           [,1]
+# [1,] 0.8468436
+```
+
+## Bug report
+
+Please submit bug reports to the [issue tracker](https://github.com/davidrusi/mombf/issues).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mombf
 
 [![Build Status](https://travis-ci.org/davidrusi/mombf.svg?branch=master)](https://travis-ci.org/davidrusi/mombf)
+<a href="https://cran.r-project.org/web/checks/check_results_mombf.html"><img border="0" src="http://www.r-pkg.org/badges/version/mombf" alt="CRAN version"></a>
 
 Bayesian model selection and averaging for regression and mixtures for non-local and selected local priors.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # mombf
+
+[![Build Status](https://travis-ci.org/davidrusi/mombf.svg?branch=master)](https://travis-ci.org/davidrusi/mombf)
+
 Bayesian model selection and averaging for regression and mixtures for non-local and selected local priors.
 
 ## Installation
@@ -7,7 +10,7 @@ Bayesian model selection and averaging for regression and mixtures for non-local
 # Install mombf from CRAN
 install.packages("mombf")
 
-# Or the the development version
+# Or the development version
 # from R-forge
 install.packages("mombf", repos = "http://R-Forge.R-project.org")
 


### PR DESCRIPTION
This PR adds a developer guide and a readme to the repository. The readme is also intended to be included with the R package, and to be shown in the "Materials" section in CRAN. The contributing guide will not be distributed with the package, therefore a `.Rbuildignore` has been added to.

To check the new files properly rendered, see [`dev_guide`](https://github.com/davidrusi/mombf/tree/dev_guide) branch. 