### PR TITLE
Add tests to mombf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,47 @@
+# folders to exclude
 doc
 Meta
+
+# exclude compiled output
+*.o
+*.so
+
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+/*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
+rsconnect/
+
+# R jupyter notebooks
+.ipynb_checkpoints/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Author: David Rossell, John D. Cook, Donatello Telesca, P. Roebuck, Oriol Abril
 Maintainer: David Rossell <rosselldavid@gmail.com>
 Depends: R (>= 2.14.0), methods, mvtnorm, ncvreg, mgcv
 Imports: Rcpp (>= 0.12.16), mclust, survival
-Suggests: parallel
+Suggests: parallel, testthat, patrick
 LinkingTo: Rcpp, RcppArmadillo
 Description: Bayesian model selection and averaging for regression and mixtures for non-local and selected local priors.
 License: GPL (>= 2) | file LICENSE
@@ -15,6 +15,3 @@ URL: https://github.com/davidrusi/mombf
 BugReports: https://github.com/davidrusi/mombf/issues
 LazyLoad: yes
 Collate: AllClasses.R AllGenerics.R alapl.R bms_ortho.R cox.R derivatives_nlps.R distribs.R dmom.R emomLM.R gam.R greedyGLM.R msPriorSpec.R modelsearch.R modelSelection.R mombf.R normaliwish.R normmix.R nlpMarginal.R pmomLM.R pmomPM.R postMode.R pplProbit.R ppmodel.R rmom.R RcppExports.R testfunction.R zellnerLM.R
-
-
-

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(mombf)
+
+test_check("mombf")

--- a/tests/testthat/data-for-tests.R
+++ b/tests/testthat/data-for-tests.R
@@ -4,5 +4,7 @@ set.seed(1234)
 n <- 20
 X3 <- matrix(rnorm(n * 3), nrow = n, ncol = 3)
 X3 <- cbind(matrix(1, nrow = n, ncol = 1), X3) # add intercept
-theta3 <- matrix(c(1, 0, 1, 0), ncol = 1)
-y3 <- X3 %*% theta3 + rnorm(n)
+theta3_truth <- matrix(c(1, 0, 1, 0), ncol = 1)
+theta3_truth_bool <- as.logical(theta3_truth)
+theta3_truth_idx <- which(theta3_truth_bool)
+y3 <- X3 %*% theta3_truth + rnorm(n)

--- a/tests/testthat/data-for-tests.R
+++ b/tests/testthat/data-for-tests.R
@@ -1,0 +1,8 @@
+set.seed(1234)
+
+# define set of data with 3 covariates for testing
+n <- 20
+X3 <- matrix(rnorm(n * 3), nrow = n, ncol = 3)
+X3 <- cbind(matrix(1, nrow = n, ncol = 1), X3) # add intercept
+theta3 <- matrix(c(1, 0, 1, 0), ncol = 1)
+y3 <- X3 %*% theta3 + rnorm(n)

--- a/tests/testthat/test-nlpMarginal.R
+++ b/tests/testthat/test-nlpMarginal.R
@@ -6,12 +6,10 @@ tolerance <- 1e-5
 
 patrick::with_parameters_test_that(
   "nlpMarginal is correctly impemented for normal family and",
-  {
-    pVar <- igprior(alpha=0.01, lambda=0.01)
-    true_covs <- which(theta3 != 0)
-    ans_max <- nlpMarginal(true_covs, y3, X3, priorCoef=pCoef, priorVar=pVar)
+  { pVar <- igprior(alpha=0.01, lambda=0.01)
+    ans_max <- nlpMarginal(theta3_truth_idx, y3, X3, priorCoef=pCoef, priorVar=pVar)
     ans_all <- nlpMarginal(
-      1:length(theta3), y3, X3, priorCoef=pCoef, priorVar=pVar
+      seq_along(theta3_truth), y3, X3, priorCoef=pCoef, priorVar=pVar
     )
     expect_true(ans_max > ans_all)
     expect_equal(ans_max, expected_max, tolerance=tolerance)
@@ -22,5 +20,27 @@ patrick::with_parameters_test_that(
     imomprior=list(pCoef=imomprior(tau=0.328), expected_max=-38.35765, expected_all=-43.9903),
     emomprior=list(pCoef=emomprior(tau=0.328), expected_max=-37.31882, expected_all=-42.475),
     zellnerprior=list(pCoef=zellnerprior(tau=0.328), expected_max=-39.81047, expected_all=-39.97039)
+  )
+)
+
+patrick::with_parameters_test_that(
+  "nlpMarginal is correctly impemented for twopiecenormal family and",
+  { pVar <- igprior(alpha=0.01, lambda=0.01)
+    ans_max <- nlpMarginal(
+      theta3_truth_idx, y3, X3, family="twopiecenormal", priorCoef=pCoef,
+      priorVar=pVar, priorSkew=pSkew
+    )
+    ans_all <- nlpMarginal(
+      seq_along(theta3_truth), y3, X3, family="twopiecenormal", priorCoef=pCoef,
+      priorVar=pVar, priorSkew=pSkew
+    )
+    expect_true(ans_max > ans_all)
+    expect_equal(ans_max, expected_max, tolerance=tolerance)
+    expect_equal(ans_all, expected_all, tolerance=tolerance)
+  },
+  patrick::cases(
+    momprior=list(pCoef=momprior(tau=0.328, r=1), pSkew=momprior(tau=0.3, r=1), expected_max=-38.64731, expected_all=-44.05285),
+    imomprior=list(pCoef=imomprior(tau=0.328), pSkew=imomprior(tau=0.3), expected_max=-39.69978, expected_all=-46.27032),
+    emomprior=list(pCoef=emomprior(tau=0.328), pSkew=emomprior(tau=0.3), expected_max=-38.33845, expected_all=-44.76512)
   )
 )

--- a/tests/testthat/test-nlpMarginal.R
+++ b/tests/testthat/test-nlpMarginal.R
@@ -4,19 +4,23 @@ library("mombf")
 source(test_path("data-for-tests.R"))
 tolerance <- 1e-5
 
-patrick::with_parameters_test_that("nlpMarginal is correctly impemented", {
-  pVar <- igprior(alpha=0.01, lambda=0.01)
-  true_covs <- which(theta3 != 0)
-  ans_max <- nlpMarginal(true_covs, y3, X3, priorCoef=pCoef, priorVar=pVar)
-  ans_all <- nlpMarginal(
-    1:length(theta3), y3, X3, priorCoef=pCoef, priorVar=pVar
-  )
-  expect_true(ans_max > ans_all)
-  expect_equal(ans_max, expected_max, tolerance=tolerance)
-  expect_equal(ans_all, expected_all, tolerance=tolerance)
-},
+patrick::with_parameters_test_that(
+  "nlpMarginal is correctly impemented for normal family and",
+  {
+    pVar <- igprior(alpha=0.01, lambda=0.01)
+    true_covs <- which(theta3 != 0)
+    ans_max <- nlpMarginal(true_covs, y3, X3, priorCoef=pCoef, priorVar=pVar)
+    ans_all <- nlpMarginal(
+      1:length(theta3), y3, X3, priorCoef=pCoef, priorVar=pVar
+    )
+    expect_true(ans_max > ans_all)
+    expect_equal(ans_max, expected_max, tolerance=tolerance)
+    expect_equal(ans_all, expected_all, tolerance=tolerance)
+  },
   patrick::cases(
     momprior=list(pCoef=momprior(tau=0.328, r=1), expected_max=-37.47804, expected_all=-41.73017),
+    imomprior=list(pCoef=imomprior(tau=0.328), expected_max=-38.35765, expected_all=-43.9903),
+    emomprior=list(pCoef=emomprior(tau=0.328), expected_max=-37.31882, expected_all=-42.475),
     zellnerprior=list(pCoef=zellnerprior(tau=0.328), expected_max=-39.81047, expected_all=-39.97039)
   )
 )

--- a/tests/testthat/test-nlpMarginal.R
+++ b/tests/testthat/test-nlpMarginal.R
@@ -1,0 +1,22 @@
+context("nlpMarginal")
+library("mombf")
+
+source(test_path("data-for-tests.R"))
+tolerance <- 1e-5
+
+patrick::with_parameters_test_that("nlpMarginal is correctly impemented", {
+  pVar <- igprior(alpha=0.01, lambda=0.01)
+  true_covs <- which(theta3 != 0)
+  ans_max <- nlpMarginal(true_covs, y3, X3, priorCoef=pCoef, priorVar=pVar)
+  ans_all <- nlpMarginal(
+    1:length(theta3), y3, X3, priorCoef=pCoef, priorVar=pVar
+  )
+  expect_true(ans_max > ans_all)
+  expect_equal(ans_max, expected_max, tolerance=tolerance)
+  expect_equal(ans_all, expected_all, tolerance=tolerance)
+},
+  patrick::cases(
+    momprior=list(pCoef=momprior(tau=0.328, r=1), expected_max=-37.47804, expected_all=-41.73017),
+    zellnerprior=list(pCoef=zellnerprior(tau=0.328), expected_max=-39.81047, expected_all=-39.97039)
+  )
+)


### PR DESCRIPTION
Use [`testthat`](https://github.com/r-lib/testthat) and [`patrick`](https://github.com/google/patrick) to automatically perform tests on relevant objects.

In this PR, tests were included for:
* [x] `nlpMarginal` normal family
  * [x] `momprior`
  * [x] `emomprior`
  * [x] `imomprior`
  * [x] `zellnerprior`
* [x] `nlpMarginal` twopiecenormal family
  * [x] `momprior`
  * [x] `emomprior`
  * [x] `imomprior`
  * zellner prior is not tested as it is not actually implemented
