### PR TITLE
Add tests for modelSelection

### DIFF
--- a/tests/testthat/data-for-tests.R
+++ b/tests/testthat/data-for-tests.R
@@ -8,3 +8,11 @@ theta3_truth <- matrix(c(1, 0, 1, 0), ncol = 1)
 theta3_truth_bool <- as.logical(theta3_truth)
 theta3_truth_idx <- which(theta3_truth_bool)
 y3 <- X3 %*% theta3_truth + rnorm(n)
+
+n <- 200
+X6 <- matrix(rnorm(n * 6), nrow = n, ncol = 6)
+X6 <- cbind(matrix(1, nrow = n, ncol = 1), X6) # add intercept
+theta6_truth <- matrix(c(0, 0, 1, 1, 0, 1, 1), ncol = 1)
+theta6_truth_bool <- as.logical(theta6_truth)
+theta6_truth_idx <- which(theta6_truth_bool)
+y6 <- X6 %*% theta6_truth + rnorm(n)

--- a/tests/testthat/test-modelSelection-enum.R
+++ b/tests/testthat/test-modelSelection-enum.R
@@ -1,0 +1,15 @@
+context("Test modelSelection with enumerate=TRUE")
+library("mombf")
+
+source(test_path("data-for-tests.R"))
+tolerance <- 1e-5
+
+patrick::with_parameters_test_that(
+  "modelSelection with pmom works for", {
+    pCoef <- momprior(tau=0.348)  # Default MOM prior on parameters
+    pDelta <- modelbbprior(1,1)   # Beta-Binomial prior for model space
+    fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef)
+  },
+  family=c("normal", "twopiecenormal", "laplace", "twopiecelaplace"),
+  test_name=family
+)

--- a/tests/testthat/test-modelSelection-enum.R
+++ b/tests/testthat/test-modelSelection-enum.R
@@ -5,11 +5,34 @@ source(test_path("data-for-tests.R"))
 tolerance <- 1e-5
 
 patrick::with_parameters_test_that(
-  "modelSelection with pmom works for", {
-    pCoef <- momprior(tau=0.348)  # Default MOM prior on parameters
-    pDelta <- modelbbprior(1,1)   # Beta-Binomial prior for model space
-    fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef)
+  "modelSelection without groups works for", {
+    pCoef <- momprior(tau=0.348)
+    pDelta <- modelbbprior(1,1)
+    log <- capture.output(
+      fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef),
+      fit2 <- modelSelection(y3~X3[,2]+X3[,3]+X3[,4], priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef),
+      fit3 <- modelSelection(as.formula("y~X2+X3+X4"), data=data.frame(X3, y=y3), priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef)
+    )
+    pp1 <- postProb(fit1)
+    pp2 <- postProb(fit2)
+    pp3 <- postProb(fit3)
+    expect_equal(pp1$modelid, pp2$modelid)
+    expect_equal(pp1$modelid, pp3$modelid)
+    expect_equal(pp1$pp, pp2$pp, tolerance=tolerance)
+    expect_equal(pp1$pp, pp3$pp, tolerance=tolerance)
   },
-  family=c("normal", "twopiecenormal", "laplace", "twopiecelaplace"),
-  test_name=family
+  patrick::cases(
+    mom_normal=list(family="normal", pCoef=momprior(tau=0.248)),
+    mom_twopiecenormal=list(family="twopiecenormal", pCoef=momprior(tau=0.248)),
+    mom_laplace=list(family="laplace", pCoef=momprior(tau=0.248)),
+    mom_twopiecelaplace=list(family="twopiecelaplace", pCoef=momprior(tau=0.248)),
+    imom_normal=list(family="normal", pCoef=imomprior(tau=0.248)),
+    imom_twopiecenormal=list(family="twopiecenormal", pCoef=imomprior(tau=0.248)),
+    imom_laplace=list(family="laplace", pCoef=imomprior(tau=0.248)),
+    imom_twopiecelaplace=list(family="twopiecelaplace", pCoef=imomprior(tau=0.248)),
+    emom_normal=list(family="normal", pCoef=emomprior(tau=0.248)),
+    emom_twopiecenormal=list(family="twopiecenormal", pCoef=emomprior(tau=0.248)),
+    emom_laplace=list(family="laplace", pCoef=emomprior(tau=0.248)),
+    emom_twopiecelaplace=list(family="twopiecelaplace", pCoef=emomprior(tau=0.248))
+  )
 )

--- a/tests/testthat/test-modelSelection-enum.R
+++ b/tests/testthat/test-modelSelection-enum.R
@@ -6,7 +6,6 @@ tolerance <- 1e-5
 
 patrick::with_parameters_test_that(
   "modelSelection without groups works for", {
-    pCoef <- momprior(tau=0.348)
     pDelta <- modelbbprior(1,1)
     log <- capture.output(
       fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef),
@@ -20,6 +19,36 @@ patrick::with_parameters_test_that(
     expect_equal(pp1$modelid, pp3$modelid)
     expect_equal(pp1$pp, pp2$pp, tolerance=tolerance)
     expect_equal(pp1$pp, pp3$pp, tolerance=tolerance)
+  },
+  patrick::cases(
+    mom_normal=list(family="normal", pCoef=momprior(tau=0.248)),
+    mom_twopiecenormal=list(family="twopiecenormal", pCoef=momprior(tau=0.248)),
+    mom_laplace=list(family="laplace", pCoef=momprior(tau=0.248)),
+    mom_twopiecelaplace=list(family="twopiecelaplace", pCoef=momprior(tau=0.248)),
+    imom_normal=list(family="normal", pCoef=imomprior(tau=0.248)),
+    imom_twopiecenormal=list(family="twopiecenormal", pCoef=imomprior(tau=0.248)),
+    imom_laplace=list(family="laplace", pCoef=imomprior(tau=0.248)),
+    imom_twopiecelaplace=list(family="twopiecelaplace", pCoef=imomprior(tau=0.248)),
+    emom_normal=list(family="normal", pCoef=emomprior(tau=0.248)),
+    emom_twopiecenormal=list(family="twopiecenormal", pCoef=emomprior(tau=0.248)),
+    emom_laplace=list(family="laplace", pCoef=emomprior(tau=0.248)),
+    emom_twopiecelaplace=list(family="twopiecelaplace", pCoef=emomprior(tau=0.248))
+  )
+)
+
+patrick::with_parameters_test_that(
+  "modelSelection with groups works for", {
+    pDelta <- modelbbprior(1,1)
+    groups <- c(1, 1, 2, 2, 3, 4, 4)
+    log <- capture.output(
+      fit <- modelSelection(
+        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE,
+        family=family, priorSkew=pCoef, priorGroup=pCoef, groups=groups
+      )
+    )
+    pprobs <- postProb(fit)
+    expect_equal(length(pprobs$modelid), 16)
+    expect_equal(as.character(pprobs$modelid[1]), "3,4,6,7")
   },
   patrick::cases(
     mom_normal=list(family="normal", pCoef=momprior(tau=0.248)),

--- a/tests/testthat/test-modelSelection-gibbs.R
+++ b/tests/testthat/test-modelSelection-gibbs.R
@@ -1,24 +1,24 @@
-context("Test modelSelection with enumerate=TRUE")
+context("Test modelSelection with Gibbs")
 library("mombf")
 
 source(test_path("data-for-tests.R"))
-tolerance <- 1e-5
+tolerance <- 5e-3
 
 patrick::with_parameters_test_that(
   "modelSelection without groups works for", {
     pDelta <- modelbbprior(1,1)
     log <- capture.output(
-      fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef),
-      fit2 <- modelSelection(y3~X3[,2]+X3[,3]+X3[,4], priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef),
-      fit3 <- modelSelection(as.formula("y~X2+X3+X4"), data=data.frame(X3, y=y3), priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE, family=family, priorSkew=pCoef)
+      fit1 <- modelSelection(y=y3, x=X3, priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE, family=family, priorSkew=pCoef),
+      fit2 <- modelSelection(y3~X3[,2]+X3[,3]+X3[,4], priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE, family=family, priorSkew=pCoef),
+      fit3 <- modelSelection(as.formula("y~X2+X3+X4"), data=data.frame(X3, y=y3), priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE, family=family, priorSkew=pCoef)
     )
     pp1 <- postProb(fit1)
     pp2 <- postProb(fit2)
     pp3 <- postProb(fit3)
-    expect_equal(pp1$modelid, pp2$modelid)
-    expect_equal(pp1$modelid, pp3$modelid)
-    expect_equal(pp1$pp, pp2$pp, tolerance=tolerance)
-    expect_equal(pp1$pp, pp3$pp, tolerance=tolerance)
+    expect_equal(as.character(pp1$modelid[1]), as.character(pp2$modelid[1]))
+    expect_equal(as.character(pp1$modelid[1]), as.character(pp3$modelid[1]))
+    expect_equal(as.numeric(pp1$pp[1]), as.numeric(pp2$pp[1]), tolerance=tolerance)
+    expect_equal(as.numeric(pp1$pp[1]), as.numeric(pp3$pp[1]), tolerance=tolerance)
   },
   patrick::cases(
     mom_auto=list(family="auto", pCoef=momprior(tau=0.348)),
@@ -43,16 +43,15 @@ patrick::with_parameters_test_that(
     groups <- c(1, 1, 2, 2, 3, 4, 4)
     log <- capture.output(
       fit <- modelSelection(
-        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=TRUE,
+        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE,
         family=family, priorSkew=pCoef, priorGroup=pCoef, groups=groups
       )
     )
     pprobs <- postProb(fit)
-    expect_equal(length(pprobs$modelid), 16)
     expect_equal(as.character(pprobs$modelid[1]), "3,4,6,7")
   },
   patrick::cases(
-    # mom_auto=list(family="auto", pCoef=momprior(tau=0.348)),
+    mom_auto=list(family="auto", pCoef=momprior(tau=0.348)),
     mom_normal=list(family="normal", pCoef=momprior(tau=0.348)),
     mom_twopiecenormal=list(family="twopiecenormal", pCoef=momprior(tau=0.348)),
     mom_laplace=list(family="laplace", pCoef=momprior(tau=0.348)),


### PR DESCRIPTION
`modelSelection` is one of the main functions of mombf. Therefore, before adding new functionalities and modifying how it works internally, some tests have been added to avoid the introduction of bugs.

Currently, `modelSelection` is tested in the following cases:
* enumerate=TRUE, no groups
  * mom, imom and emom as priorcoef for all 4 families using as arguments:
    * `x`, `y`
    * `y` as formula `y~x[,1]...`
    * `y` as string formula and `data` argument
* enumerate=TRUE with groups
  * mom, imom and emom as priorcoef and priorgroup (for simplicity, the same prior is used for both args) for all 4 families. In this case, only the `x`, `y` syntax is used as it seems to be the only syntax compatible with groups.