### PR TITLE
Implement normalid + group Zellner marginal function

### DIFF
--- a/src/covariancemat.cpp
+++ b/src/covariancemat.cpp
@@ -8,6 +8,7 @@
 
  - ncolx: number of columns in x (equivalently, number of rows & columns in XtX)
 
+TODO: store block determinants. A vector of length ngroups?
 */
 covariancemat::covariancemat(int ncolx) {
 

--- a/src/covariancemat.cpp
+++ b/src/covariancemat.cpp
@@ -1,0 +1,53 @@
+#include <stdexcept>
+#include "covariancemat.h"
+
+
+/*Constructor
+
+ INPUT
+
+ - ncolx: number of columns in x (equivalently, number of rows & columns in XtX)
+
+*/
+covariancemat::covariancemat(int ncolx) {
+
+  this->ncolx= ncolx;
+
+  (this->XtXs)= arma::sp_mat(ncolx, ncolx);
+  (this->XtXcomputed)= arma::SpMat<short>(ncolx, ncolx);
+}
+
+//Class destructor
+covariancemat::~covariancemat() { }
+
+
+
+//Access element with matrix-type index, e.g. A(0,1) is element in row 0, column 1
+double covariancemat::at(int i, int j) {
+
+  if (XtXcomputed.at(i,j) == 1) {
+    return XtXs.at(i,j);
+  } else {
+    throw std::runtime_error("covariancemat value not yet computed");
+  }
+}
+
+// Check if element has already been computed with matrix-type index,
+// e.g. A(0,1) is element in row 0, column 1
+bool covariancemat::computed_at(int i, int j) {
+
+  if (XtXcomputed.at(i,j) == 0) {  //if this entry has not been already computed
+    return false;
+  } else {
+    return true;
+  }
+}
+
+// Set element with matrix-type index and mark it as computed,
+// e.g. A(0,1) is element in row 0, column 1
+void covariancemat::set(int i, int j, double value) {
+
+  XtXcomputed(i,j)= 1;
+  XtXs(i,j)= value;
+}
+

--- a/src/covariancemat.h
+++ b/src/covariancemat.h
@@ -1,0 +1,45 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+
+#ifndef COVARIANCEMAT
+#define COVARIANCEMAT 1
+
+// we only include RcppArmadillo.h which pulls Rcpp.h in for us
+#include "RcppArmadillo.h"
+
+// via the depends attribute we tell Rcpp to create hooks for
+// RcppArmadillo so that the build process will know what to do
+//
+// [[Rcpp::depends(RcppArmadillo)]]
+
+using namespace std;
+
+
+// THIS CLASS HANDLES STORAGE OF COVARIANCE MATRICES
+// IT ALLOWS INCREMENTALLY POPULATING THE MATRIX AS ELEMENTS ARE NEEDED, SO ONE DOESN'T NEED TO PRE-COMPUTE AND ALLOCATE MEMORY FOR ALL ENTRIES.
+// WHEN AN ENTRY IS REQUIRED IT IS COMPUTED ON-THE-FLY (OUTSIDE COVARIANCEMAT CLASS) AND STORED INTERNALLY INTO A SPARSE MATRIX USING CLASS SpMat FROM ARMADILLO
+//
+// NOTE: all indexes in this class start at 0, e.g. A(0,1) returns element in row 0, column 1; A(0) returns element in row 0 column 0
+//
+
+class covariancemat {
+
+public:
+
+  covariancemat(int ncolx);
+
+  ~covariancemat();
+
+  double at(int i, int j);  //Access element with matrix-type index, e.g. A(0,1) is element in row 0, column 1
+  bool computed_at(int i, int j);
+  void set(int i, int j, double value);
+
+private:
+
+  int ncolx;
+  arma::sp_mat XtXs;  //equivalent to SpMat<double> XtXs
+  arma::SpMat<short> XtXcomputed; //bool entries indicating if XtX has been computed
+
+};
+
+#endif
+

--- a/src/crossprodmat.cpp
+++ b/src/crossprodmat.cpp
@@ -75,20 +75,6 @@ crossprodmat::crossprodmat(double *mymat, int nrowx, int ncolx, bool dense) {
   }
 }
 
-
-crossprodmat::crossprodmat(int ncolx) {
-
-  this->nrowx= 0;
-  this->ncolx= ncolx;
-  this->userowsini= 0;
-  this->nuserows= 0;
-  this->userows= NULL;
-
-  this->dense= false;
-  (this->XtXs)= arma::sp_mat(ncolx, ncolx);
-  (this->XtXcomputed)= arma::SpMat<short>(ncolx, ncolx);
-}
-
 //Class destructor
 crossprodmat::~crossprodmat() { }
 
@@ -121,31 +107,6 @@ double crossprodmat::at(int i, int j) {
   }
 }
 
-// Check if element has already been computed with matrix-type index,
-// e.g. A(0,1) is element in row 0, column 1
-bool crossprodmat::computed_at(int i, int j) {
-
-  if (dense) {
-
-    return true;
-
-  } else {
-
-    if (XtXcomputed.at(i,j) == 0) {  //if this entry has not been already computed
-      return false;
-    } else {
-      return true;
-    }
-  }
-}
-
-// Set element with matrix-type index and mark it as computed,
-// e.g. A(0,1) is element in row 0, column 1
-void crossprodmat::set(int i, int j, double value) {
-
-  XtXcomputed(i,j)= 1;
-  XtXs(i,j)= value;
-}
 
 //Access element with vector-type index A(k)= A(i,j) where j= k/nrow; i= k % nrow
 double crossprodmat::at(int k) {

--- a/src/crossprodmat.cpp
+++ b/src/crossprodmat.cpp
@@ -97,9 +97,9 @@ double crossprodmat::at(int i, int j) {
 
       int iini, jini, k; double ans= 0;
       if (this->userows ==NULL) {
-	for (k= this->userowsini, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[k + iini] * x[k + jini];
+        for (k= this->userowsini, iini=i*nrowx, jini=j*nrowx; k< this->nuserows+this->userowsini; k++) ans += x[k + iini] * x[k + jini];
       } else {
-	for (k= 0, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[(this->userows[k]) + iini] * x[(this->userows[k]) + jini];
+        for (k= 0, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[(this->userows[k]) + iini] * x[(this->userows[k]) + jini];
       }
 
       XtXcomputed(i,j)= 1;
@@ -128,11 +128,11 @@ double crossprodmat::at(int k) {
       int iini, jini, k; double ans= 0;
       if (this->userows ==NULL) {
 
-	for (k= this->userowsini, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[k + iini] * x[k + jini];
+        for (k= this->userowsini, iini=i*nrowx, jini=j*nrowx; k< this->nuserows+this->userowsini; k++) ans += x[k + iini] * x[k + jini];
 
       } else {
 
-	for (k= 0, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[(this->userows[k]) + iini] * x[(this->userows[k]) + jini];
+        for (k= 0, iini=i*nrowx, jini=j*nrowx; k< this->nuserows; k++) ans += x[(this->userows[k]) + iini] * x[(this->userows[k]) + jini];
 
       }
 

--- a/src/crossprodmat.h
+++ b/src/crossprodmat.h
@@ -59,13 +59,10 @@ public:
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense, int nuserows, int *userows); //if dense==true, mymat is pointer to pre-computed XtX; if dense==false, mymat is pointer to x
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense, int nuserows, int userowsini);
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense);
-  crossprodmat(int ncolx);
 
   ~crossprodmat();
 
   double at(int i, int j);  //Access element with matrix-type index, e.g. A(0,1) is element in row 0, column 1
-  bool computed_at(int i, int j);
-  void set(int i, int j, double value);
   double at(int k);  //Access element with vector-type index A(k)= A(i,j) where j= k/nrow; i= k % nrow
 
   void choldc(int idxini, int idxfi, double *cholXtX, double *detXtX, bool *posdef); //Cholesky decomp and determinant

--- a/src/crossprodmat.h
+++ b/src/crossprodmat.h
@@ -59,10 +59,13 @@ public:
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense, int nuserows, int *userows); //if dense==true, mymat is pointer to pre-computed XtX; if dense==false, mymat is pointer to x
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense, int nuserows, int userowsini);
   crossprodmat(double *mymat, int nrowx, int ncolx, bool dense);
+  crossprodmat(int ncolx);
 
   ~crossprodmat();
 
   double at(int i, int j);  //Access element with matrix-type index, e.g. A(0,1) is element in row 0, column 1
+  bool computed_at(int i, int j);
+  void set(int i, int j, double value);
   double at(int k);  //Access element with vector-type index A(k)= A(i,j) where j= k/nrow; i= k % nrow
 
   void choldc(int idxini, int idxfi, double *cholXtX, double *detXtX, bool *posdef); //Cholesky decomp and determinant

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -286,6 +286,10 @@ int mspriorCode(int *prCoef, int *prGroup, struct marginalPars *pars) {
       ans= 33;
     } else if ((*prCoef==3) & (*prGroup==13)) { //Zellner + group Zellner
       ans= 43;
+    } else if ((*prCoef==3) & (*prGroup==4)) { //Zellner + normalid
+      ans= 44;
+    } else if ((*prCoef==4) & (*prGroup==13)) { //normalid + group Zellner
+      ans= 58;
     } else if ((*prCoef==13) & (*prGroup==13)) { //group Zellner + group Zellner
       ans= 53;
     } else {
@@ -324,6 +328,10 @@ pt2margFun set_marginalFunction(int *priorcode, int *knownphi, int *family, stru
       ans= pemomgzellMarg;
     } else if (*priorcode==43) {
       ans= zellgzellMarg;
+    } else if (*priorcode==44) {
+      ans= zellnormidMarg;
+    } else if (*priorcode==58) {
+      ans= normidgzellMarg;
     } else {
       Rf_error("The prior in (priorCoef,priorGroup) not currently implemented for linear regression");
     }
@@ -2178,6 +2186,15 @@ double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   Rf_error("Zellner + block Zellner not currently implemented for linear regression");
 }
 
+// Zellner on individual coef, normalid on groups
+double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
+  Rf_error("Zellner + block Zellner not currently implemented for linear regression");
+}
+
+// Zellner on individual coef, block Zellner on groups
+double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
+  Rf_error("Zellner + block Zellner not currently implemented for linear regression");
+}
 
 //*************************************************************************************
 // MARGINAL LIKELIHOOD FOR ACCELERATED FAILURE TIME MODELS

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2244,9 +2244,7 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
     }
     logtaus = singlevarcount*log(tau) + (*nsel - singlevarcount) * log(taugroup);
     logdetV0 = log(detV0tau) - logtaus;
-    Rcpp::Rcout << "det(V0) " << logdetV0 << "\n";
     invdet_posdef(S,*nsel,Sinv,&detS);
-    Rcpp::Rcout << "det(S) " << detS << "\n";
     Asym_xsel(Sinv,*nsel,(*pars).ytX,sel,m);
     nuhalf= .5*(*(*pars).n + *(*pars).alpha);
 

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2188,7 +2188,50 @@ double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
 
 // Zellner on individual coef, normalid on groups
 double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
-  Rf_error("Zellner + block Zellner not currently implemented for linear regression");
+  int i, j, p_i, varcount, groupcount;
+  double num, den, ans=0.0, term1, *m, **S, **Sinv, detS, adj, tau= *(*pars).tau, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
+  if (*nsel ==0) {
+
+    term1= .5*(*(*pars).n + *(*pars).alpha);
+    num= .5*(*(*pars).alpha)*log(*(*pars).lambda) + gamln(&term1);
+    den= .5*(*(*pars).n)*(LOG_M_PI) + gamln(&alphahalf);
+    ans= num -den - term1*log(*(*pars).lambda + *(*pars).sumy2);
+
+  } else {
+
+    // TODO: improve loop to define matrix, see findselgroups in line 1732
+    nvarinselgroups= dvector(0, min_xy(*nsel, *((*pars).ngroups))); firstingroup= dvector(0, min_xy(*nsel, *((*pars).ngroups))); selgroups= dvector(0, *nsel -1);
+    findselgroups(nvarinselgroups, firstingroup, &nselgroups, selgroups, sel, nsel, (*pars).nvaringroup, (*pars).ngroups); //copy subset of nvaringroup into nvarinselgroups
+    m= dvector(1,*nsel); S= dmatrix(1,*nsel,1,*nsel); Sinv= dmatrix(1,*nsel,1,*nsel);
+    addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
+    adj= (tau+1)/tau;
+    for (varcount=1, groupcount=0; varcount <= *nsel; varcount++, groupcount++) {
+      p_i = nvarinselgroups[groupcount];
+      if (p_i==1) {
+        S[varcount][varcount] = S[varcount][varcount] * 1/tau;
+      } else {
+        for (i=varcount; i<=varcount + p_i; i++) {
+          S[i][i]= S[i][i] * adj;
+          for (j=i+1; j<=varcount + p_i; j++) { S[i][j]= S[i][j] * adj; }
+        }
+        varcount = varcount + p_i - 1;
+      }
+    }
+    invdet_posdef(S,*nsel,Sinv,&detS);
+    Asym_xsel(Sinv,*nsel,(*pars).ytX,sel,m);
+    nuhalf= .5*(*(*pars).n + *(*pars).alpha);
+
+    ss= *(*pars).lambda + *(*pars).sumy2 - quadratic_xtAx(m,S,1,*nsel);
+    num= gamln(&nuhalf) + alphahalf*log(lambdahalf) + nuhalf*(log(2.0) - log(ss));
+    den= .5*(*(*pars).n * LOG_M_2PI) + .5 * (*nsel) *log((*(*pars).tau)+1.0) + gamln(&alphahalf);
+    //den= .5*(*(*pars).n * LOG_M_2PI + log(detS)) + .5 * (*nsel) *log(*(*pars).tau) + gamln(&alphahalf);
+    ans= num - den;
+
+    free_dvector(m,1,*nsel); free_dmatrix(S,1,*nsel,1,*nsel); free_dmatrix(Sinv,1,*nsel,1,*nsel);
+
+  }
+  if (*(*pars).logscale !=1) { ans= exp(ans); }
+  return ans;
 }
 
 // Zellner on individual coef, block Zellner on groups

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2186,8 +2186,13 @@ double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   Rf_error("Zellner + block Zellner not currently implemented for linear regression");
 }
 
-// Zellner on individual coef, normalid on groups
+// Zellner on individual coef, normid on groups
 double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
+  Rf_error("Zellner + normalid not currently implemented for linear regression");
+}
+
+// Zellner on individual coef, normalid on groups
+double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   int i, j, p_i, varcount, groupcount;
   double num, den, ans=0.0, term1, *m, **S, **Sinv, detS, adj, tau= *(*pars).tau, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
   if (*nsel ==0) {
@@ -2205,16 +2210,17 @@ double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
     m= dvector(1,*nsel); S= dmatrix(1,*nsel,1,*nsel); Sinv= dmatrix(1,*nsel,1,*nsel);
     addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
     adj= (tau+1)/tau;
-    for (varcount=1, groupcount=0; varcount <= *nsel; varcount++, groupcount++) {
+    for (varcount=1, groupcount=0; varcount <= *nsel; groupcount++) {
       p_i = (int) nvarinselgroups[groupcount];
       if (p_i==1) {
         S[varcount][varcount] = S[varcount][varcount] * 1/tau;
+        varcount++;
       } else {
         for (i=varcount; i<varcount + p_i; i++) {
           S[i][i]= S[i][i] * adj;
           for (j=i+1; j<varcount + p_i; j++) { S[i][j]= S[i][j] * adj; }
         }
-        varcount = varcount + p_i - 1;
+        varcount = varcount + p_i;
       }
     }
     invdet_posdef(S,*nsel,Sinv,&detS);
@@ -2232,11 +2238,6 @@ double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
   }
   if (*(*pars).logscale !=1) { ans= exp(ans); }
   return ans;
-}
-
-// Zellner on individual coef, block Zellner on groups
-double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
-  Rf_error("Zellner + block Zellner not currently implemented for linear regression");
 }
 
 //*************************************************************************************

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2206,13 +2206,13 @@ double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
     addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
     adj= (tau+1)/tau;
     for (varcount=1, groupcount=0; varcount <= *nsel; varcount++, groupcount++) {
-      p_i = nvarinselgroups[groupcount];
+      p_i = (int) nvarinselgroups[groupcount];
       if (p_i==1) {
         S[varcount][varcount] = S[varcount][varcount] * 1/tau;
       } else {
-        for (i=varcount; i<=varcount + p_i; i++) {
+        for (i=varcount; i<varcount + p_i; i++) {
           S[i][i]= S[i][i] * adj;
-          for (j=i+1; j<=varcount + p_i; j++) { S[i][j]= S[i][j] * adj; }
+          for (j=i+1; j<varcount + p_i; j++) { S[i][j]= S[i][j] * adj; }
         }
         varcount = varcount + p_i - 1;
       }

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -286,8 +286,6 @@ int mspriorCode(int *prCoef, int *prGroup, struct marginalPars *pars) {
       ans= 33;
     } else if ((*prCoef==3) & (*prGroup==13)) { //Zellner + group Zellner
       ans= 43;
-    } else if ((*prCoef==3) & (*prGroup==4)) { //Zellner + normalid
-      ans= 44;
     } else if ((*prCoef==4) & (*prGroup==13)) { //normalid + group Zellner
       ans= 58;
     } else if ((*prCoef==13) & (*prGroup==13)) { //group Zellner + group Zellner
@@ -328,8 +326,6 @@ pt2margFun set_marginalFunction(int *priorcode, int *knownphi, int *family, stru
       ans= pemomgzellMarg;
     } else if (*priorcode==43) {
       ans= zellgzellMarg;
-    } else if (*priorcode==44) {
-      ans= zellnormidMarg;
     } else if (*priorcode==58) {
       ans= normidgzellMarg;
     } else {
@@ -2184,12 +2180,87 @@ double pemomgzellMarg(int *sel, int *nsel, struct marginalPars *pars) {
 
 // Zellner on individual coef, block Zellner on groups
 double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
-  Rf_error("Zellner + block Zellner not currently implemented for linear regression");
-}
+  int i_var, i, j_group, j_var, j, p_i, varcount, groupcount, *groupsel, singlevarcount=0;
+  double num, den, ans=0.0, aux, term1, *m, **S, **Sinv, **Vinv, **Vinv_chol, detS, detVinvtau, logdetVinv, tau= *(*pars).tau, taugroup=*(*pars).taugroup, logtaus, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
+  crossprodmat *V0inv=(*pars).V0inv;
+  bool posdef;
+  if (*nsel ==0) {
 
-// Zellner on individual coef, normid on groups
-double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
-  Rf_error("Zellner + normalid not currently implemented for linear regression");
+    term1= .5*(*(*pars).n + *(*pars).alpha);
+    num= .5*(*(*pars).alpha)*log(*(*pars).lambda) + gamln(&term1);
+    den= .5*(*(*pars).n)*(LOG_M_PI) + gamln(&alphahalf);
+    ans= num -den - term1*log(*(*pars).lambda + *(*pars).sumy2);
+
+  } else {
+
+    nvarinselgroups= dvector(0, min_xy(*nsel, *((*pars).ngroups))); firstingroup= dvector(0, min_xy(*nsel, *((*pars).ngroups))); selgroups= dvector(0, *nsel -1);
+    findselgroups(nvarinselgroups, firstingroup, &nselgroups, selgroups, sel, nsel, (*pars).nvaringroup, (*pars).ngroups); //copy subset of nvaringroup into nvarinselgroups
+    m= dvector(1,*nsel); S= dmatrix(1,*nsel,1,*nsel); Sinv= dmatrix(1,*nsel,1,*nsel);
+    Vinv = dmatrix(1, *nsel, 1, *nsel); Vinv_chol = dmatrix(1, *nsel, 1, *nsel);
+    addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
+    for (i=1; i<=*nsel; i++) {
+      for (j=i; j<=*nsel; j++) {
+        Vinv[i][j] = 0;
+      }
+    }
+    for (varcount=1, groupcount=0; varcount <= *nsel; groupcount++) {
+      p_i = (int) nvarinselgroups[groupcount];
+      if (p_i==1) {
+        for (j_group=groupcount; j_group< nselgroups; j_group++) {
+          if (nvarinselgroups[j_group] == 1) {
+            j_var = firstingroup[j_group] + 1;
+            if (V0inv->computed_at(sel[varcount-1], sel[j_var-1])) {
+              Vinv[varcount][j_var] = V0inv->at(sel[varcount-1], sel[j_var-1]);
+              S[varcount][j_var]+=Vinv[varcount][j_var];
+            } else {
+              aux = (*pars).XtX->at(sel[varcount-1], sel[j_var-1])/tau;
+              V0inv->set(sel[varcount-1], sel[j_var-1], aux);
+              Vinv[varcount][j_var]= aux;
+              S[varcount][j_var]+=aux;
+            }
+          }
+        }
+        varcount++;
+        singlevarcount++;
+      } else {
+        groupsel = ivector(0,p_i);
+        for (i=0; i<p_i; i++) {  groupsel[i] = sel[varcount-1+i]; }
+        for (i_var=varcount, i=0; i<p_i; i_var++, i++) {
+          for (j_var=i_var, j=i; j<p_i; j_var++, j++) {
+            if (V0inv->computed_at(groupsel[i], groupsel[j])) {
+              Vinv[i_var][j_var]= V0inv->at(groupsel[i], groupsel[j]);
+              S[i_var][j_var]+=Vinv[i_var][j_var];
+            } else {
+              aux = (*pars).XtX->at(groupsel[i], groupsel[j])/taugroup;
+              V0inv->set(groupsel[i], groupsel[j], aux);
+              Vinv[i_var][j_var]= aux;
+              S[i_var][j_var]+=aux;
+            }
+          }
+        }
+        varcount = varcount + p_i;
+        free_ivector(groupsel,0,p_i);
+      }
+    }
+    choldc(Vinv, *nsel, Vinv_chol, &posdef);
+    detVinvtau = choldc_det(Vinv_chol, *nsel);
+    logtaus = singlevarcount*log(tau) + (*nsel - singlevarcount) * log(taugroup);
+    logdetVinv = log(detVinvtau) + logtaus;
+    invdet_posdef(S,*nsel,Sinv,&detS);
+    Asym_xsel(Sinv,*nsel,(*pars).ytX,sel,m);
+    nuhalf= .5*(*(*pars).n + *(*pars).alpha);
+
+    ss= *(*pars).lambda + *(*pars).sumy2 - quadratic_xtAx(m,S,1,*nsel);
+    num= gamln(&nuhalf) + alphahalf*log(lambdahalf) + nuhalf*(log(2.0) - log(ss));
+    den= .5*(*(*pars).n * LOG_M_2PI + log(detS) - logdetVinv) + .5 * logtaus + gamln(&alphahalf);
+    ans= num - den;
+
+    free_dvector(m,1,*nsel); free_dmatrix(S,1,*nsel,1,*nsel); free_dmatrix(Sinv,1,*nsel,1,*nsel);
+    free_dmatrix(Vinv,1,*nsel,1,*nsel); free_dmatrix(Vinv_chol,1,*nsel,1,*nsel);
+
+  }
+  if (*(*pars).logscale !=1) { ans= exp(ans); }
+  return ans;
 }
 
 // Zellner on individual coef, normalid on groups

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -10,6 +10,7 @@
 //Include other headers
 #include "cstat.h"
 #include "crossprodmat.h"
+#include "covariancemat.h"
 #include "modelSel.h"
 #include "modselIntegrals.h"
 #include "modselFunction.h"
@@ -897,7 +898,7 @@ void set_marginalPars(struct marginalPars *pars, int *n,int *nuncens,int *p,doub
   (*pars).ytX= ytX;
   (*pars).XtXuncens= XtXuncens;
   (*pars).ytXuncens= ytXuncens;
-  (*pars).V0inv = new crossprodmat(*p);
+  (*pars).V0inv = new covariancemat(*p);
   (*pars).method= method;
   (*pars).hesstype= hesstype;
   (*pars).optimMethod= optimMethod;
@@ -2182,7 +2183,7 @@ double pemomgzellMarg(int *sel, int *nsel, struct marginalPars *pars) {
 double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   int i_var, i, j_group, j_var, j, p_i, varcount, groupcount, *groupsel, singlevarcount=0;
   double num, den, ans=0.0, aux, term1, *m, **S, **Sinv, **Vinv, **Vinv_chol, detS, detVinvtau, logdetVinv, tau= *(*pars).tau, taugroup=*(*pars).taugroup, logtaus, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
-  crossprodmat *V0inv=(*pars).V0inv;
+  covariancemat *V0inv=(*pars).V0inv;
   bool posdef;
   if (*nsel ==0) {
 
@@ -2267,7 +2268,7 @@ double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
 double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   int i_var, i, j_var, j, p_i, varcount, groupcount, *groupsel, singlevarcount=0;
   double num, den, ans=0.0, aux, term1, *m, **S, **Sinv, **Vinv, **Vinv_chol, detS, detVinvtau, logdetVinv, tau= *(*pars).tau, taugroup=*(*pars).taugroup, logtaus, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
-  crossprodmat *V0inv=(*pars).V0inv;
+  covariancemat *V0inv=(*pars).V0inv;
   bool posdef;
   if (*nsel ==0) {
 

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2194,7 +2194,7 @@ double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
 // Zellner on individual coef, normalid on groups
 double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   int i_var, i, j_var, j, p_i, varcount, groupcount, *groupsel, singlevarcount=0;
-  double num, den, ans=0.0, term1, *m, **S, **Sinv, **XtX_group, **XtX_groupinv, **V0, **V0inv, detS, detV0tau, logdetV0, detXtX_group, tau= *(*pars).tau, taugroup=*(*pars).taugroup, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
+  double num, den, ans=0.0, term1, *m, **S, **Sinv, **XtX_group, **XtX_groupinv, **V0, **V0inv, detS, detV0tau, logdetV0, detXtX_group, tau= *(*pars).tau, taugroup=*(*pars).taugroup, logtaus, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
   if (*nsel ==0) {
 
     term1= .5*(*(*pars).n + *(*pars).alpha);
@@ -2242,7 +2242,8 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
         S[i][j]+=V0inv[i][j];
       }
     }
-    logdetV0 = log(detV0tau) - singlevarcount*log(tau) - (*nsel - singlevarcount) * log(taugroup);
+    logtaus = singlevarcount*log(tau) + (*nsel - singlevarcount) * log(taugroup);
+    logdetV0 = log(detV0tau) - logtaus;
     Rcpp::Rcout << "det(V0) " << logdetV0 << "\n";
     invdet_posdef(S,*nsel,Sinv,&detS);
     Rcpp::Rcout << "det(S) " << detS << "\n";
@@ -2251,7 +2252,7 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
 
     ss= *(*pars).lambda + *(*pars).sumy2 - quadratic_xtAx(m,S,1,*nsel);
     num= gamln(&nuhalf) + alphahalf*log(lambdahalf) + nuhalf*(log(2.0) - log(ss));
-    den= .5*(*(*pars).n * LOG_M_2PI + log(detS) + logdetV0) + .5 * (*nsel) *log(tau) + gamln(&alphahalf);
+    den= .5*(*(*pars).n * LOG_M_2PI + log(detS) + logdetV0) + .5 * logtaus + gamln(&alphahalf);
     ans= num - den;
 
     free_dvector(m,1,*nsel); free_dmatrix(S,1,*nsel,1,*nsel); free_dmatrix(Sinv,1,*nsel,1,*nsel);

--- a/src/modelSel.cpp
+++ b/src/modelSel.cpp
@@ -2194,8 +2194,7 @@ double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars) {
 // Zellner on individual coef, normalid on groups
 double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
   int i_var, i, j_var, j, p_i, varcount, groupcount, *groupsel;
-  double num, den, ans=0.0, term1, *m, **S, **Sinv, **XtX_group, **XtX_groupinv, **V0, **cholV0, detS, detV0, detXtX_group, aux, tau= *(*pars).tau, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
-  bool posdef=true;
+  double num, den, ans=0.0, term1, *m, **S, **Sinv, **XtX_group, **XtX_groupinv, **V0, **V0inv, detS, detV0, detXtX_group, tau= *(*pars).tau, taugroup=*(*pars).taugroup, nuhalf, alphahalf=.5*(*(*pars).alpha), lambdahalf=.5*(*(*pars).lambda), ss, zero=0, *nvarinselgroups, *firstingroup, nselgroups, *selgroups;
   if (*nsel ==0) {
 
     term1= .5*(*(*pars).n + *(*pars).alpha);
@@ -2208,18 +2207,16 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
     nvarinselgroups= dvector(0, min_xy(*nsel, *((*pars).ngroups))); firstingroup= dvector(0, min_xy(*nsel, *((*pars).ngroups))); selgroups= dvector(0, *nsel -1);
     findselgroups(nvarinselgroups, firstingroup, &nselgroups, selgroups, sel, nsel, (*pars).nvaringroup, (*pars).ngroups); //copy subset of nvaringroup into nvarinselgroups
     m= dvector(1,*nsel); S= dmatrix(1,*nsel,1,*nsel); Sinv= dmatrix(1,*nsel,1,*nsel);
-    V0 = dmatrix(1, *nsel, 1, *nsel); cholV0 = dmatrix(1, *nsel, 1, *nsel);
+    V0 = dmatrix(1, *nsel, 1, *nsel); V0inv = dmatrix(1, *nsel, 1, *nsel);
     for (i=1; i<=*nsel; i++) {
       for (j=1; j<=*nsel; j++) {
         V0[i][j] = 0;
       }
     }
-    addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
     for (varcount=1, groupcount=0; varcount <= *nsel; groupcount++) {
       p_i = (int) nvarinselgroups[groupcount];
       if (p_i==1) {
-        S[varcount][varcount] = S[varcount][varcount] + 1/tau;
-        V0[varcount][varcount] = 1/tau;
+        V0[varcount][varcount] = tau;
         varcount++;
       } else {
         XtX_group = dmatrix(1,p_i,1,p_i); XtX_groupinv = dmatrix(1,p_i,1,p_i);
@@ -2229,10 +2226,7 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
         invdet_posdef(XtX_group,p_i,XtX_groupinv,&detXtX_group);
         for (i_var=varcount, i=1; i<=p_i; i_var++, i++) {
           for (j_var=i_var, j=i; j<=p_i; j_var++, j++) {
-            aux = XtX_groupinv[i][j]/tau;
-            S[i_var][j_var]= S[i_var][j_var] + aux;
-            V0[i_var][j_var]= aux;
-            Rcpp::Rcout << XtX_groupinv[i][j] << "\n";
+            V0[i_var][j_var]= XtX_groupinv[i][j]*taugroup;
           }
         }
         varcount = varcount + p_i;
@@ -2240,21 +2234,26 @@ double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars) {
         free_ivector(groupsel,0,p_i);
       }
     }
-    choldc(V0, *nsel, cholV0, &posdef);
-    detV0 = choldc_det(cholV0, *nsel);
-    Rcpp::Rcout << "detv0 " << detV0 << "\n";
+    invdet_posdef(V0,*nsel,V0inv,&detV0);
+    addct2XtX(&zero,(*pars).XtX,sel,nsel,(*pars).p,S);  //copy XtX onto S
+    for (i=1; i<=*nsel; i++) {
+      for (j=i; j<=*nsel; j++) {
+        S[i][j]+=V0inv[i][j];
+      }
+    }
+    Rcpp::Rcout << "det(V0) " << detV0 << "\n";
     invdet_posdef(S,*nsel,Sinv,&detS);
+    Rcpp::Rcout << "det(S) " << detS << "\n";
     Asym_xsel(Sinv,*nsel,(*pars).ytX,sel,m);
     nuhalf= .5*(*(*pars).n + *(*pars).alpha);
 
-    // check normalization
     ss= *(*pars).lambda + *(*pars).sumy2 - quadratic_xtAx(m,S,1,*nsel);
     num= gamln(&nuhalf) + alphahalf*log(lambdahalf) + nuhalf*(log(2.0) - log(ss));
     den= .5*(*(*pars).n * LOG_M_2PI + log(detS) + log(detV0)) + .5 * (*nsel) *log(tau) + gamln(&alphahalf);
     ans= num - den;
 
     free_dvector(m,1,*nsel); free_dmatrix(S,1,*nsel,1,*nsel); free_dmatrix(Sinv,1,*nsel,1,*nsel);
-    free_dmatrix(V0,1,*nsel,1,*nsel); free_dmatrix(cholV0,1,*nsel,1,*nsel);
+    free_dmatrix(V0,1,*nsel,1,*nsel); free_dmatrix(V0inv,1,*nsel,1,*nsel);
 
   }
   if (*(*pars).logscale !=1) { ans= exp(ans); }

--- a/src/modelSel.h
+++ b/src/modelSel.h
@@ -62,6 +62,7 @@ struct marginalPars {
   double *x;
   crossprodmat *XtX;  //t(x) %*% x using all observations
   crossprodmat *XtXuncens; //t(x) %*% x using uncensored observations
+  crossprodmat *V0inv;  // covariance matrix for coef and groups priors
   double *ytX;             //t(x) %*% y using all observations
   double *ytXuncens;       //t(x) %*% y using uncensored observations
   double *m;  //Sinv * Xty   (needed by mom and emom)

--- a/src/modelSel.h
+++ b/src/modelSel.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <stdlib.h>
 #include "crossprodmat.h"
+#include "covariancemat.h"
 #include "Polynomial.h"
 
 
@@ -62,7 +63,7 @@ struct marginalPars {
   double *x;
   crossprodmat *XtX;  //t(x) %*% x using all observations
   crossprodmat *XtXuncens; //t(x) %*% x using uncensored observations
-  crossprodmat *V0inv;  // covariance matrix for coef and groups priors
+  covariancemat *V0inv;  // covariance matrix for coef and groups priors
   double *ytX;             //t(x) %*% y using all observations
   double *ytXuncens;       //t(x) %*% y using uncensored observations
   double *m;  //Sinv * Xty   (needed by mom and emom)

--- a/src/modelSel.h
+++ b/src/modelSel.h
@@ -266,7 +266,11 @@ double pemomgzellMarg(int *sel, int *nsel, struct marginalPars *pars);
 // Zellner on individual coef, block Zellner on groups
 double zellgzellMarg (int *sel, int *nsel, struct marginalPars *pars);
 
+// Zellner on individual coef, normalid on groups
+double zellnormidMarg (int *sel, int *nsel, struct marginalPars *pars);
 
+// normalid on individual coef, group Zellner on groups
+double normidgzellMarg (int *sel, int *nsel, struct marginalPars *pars);
 
 //*************************************************************************************
 // MARGINAL LIKELIHOOD FOR ACCELERATED FAILURE TIME MODELS

--- a/tests/testthat/test-modelSelection-gibbs.R
+++ b/tests/testthat/test-modelSelection-gibbs.R
@@ -40,7 +40,7 @@ patrick::with_parameters_test_that(
 )
 
 patrick::with_parameters_test_that(
-  "modelSelection with groups works for", {
+  "modelSelection with groups (pCoef=pGroup) works for", {
     pDelta <- modelbbprior(1,1)
     groups <- c(1, 1, 2, 2, 3, 4, 4)
     log <- capture.output(
@@ -67,6 +67,25 @@ patrick::with_parameters_test_that(
     emom_twopiecelaplace=list(family="twopiecelaplace", pCoef=emomprior(tau=0.348))
   )
 )
+
+patrick::with_parameters_test_that(
+  "modelSelection with groups (pCoef!=pGroup, tests crossprodmat for covariance matrix) works for", {
+    pDelta <- modelbbprior(1,1)
+    groups <- c(1, 1, 2, 2, 3, 4, 4)
+    log <- capture.output(
+      fit <- modelSelection(
+        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE,
+        family=family, priorSkew=pCoef, priorGroup=pGroup, groups=groups
+      )
+    )
+    pprobs <- postProb(fit)
+    expect_true("3,4,6,7" %in% pprobs$modelid[1:4])
+  },
+  patrick::cases(
+    normid_gzell=list(family="normal", pCoef=normalidprior(tau=0.348), pGroup=groupzellnerprior(tau=0.4))
+  )
+)
+
 
 test_that(
   "modelSelection with smoothterms and no groups works", {

--- a/tests/testthat/test-modelSelection-gibbs.R
+++ b/tests/testthat/test-modelSelection-gibbs.R
@@ -69,12 +69,12 @@ patrick::with_parameters_test_that(
 )
 
 patrick::with_parameters_test_that(
-  "modelSelection with groups (pCoef!=pGroup, tests crossprodmat for covariance matrix) works for", {
+  "modelSelection with groups (pCoef!=pGroup), crossprodmat and covariancemat work for", {
     pDelta <- modelbbprior(1,1)
     groups <- c(1, 1, 2, 2, 3, 4, 4)
     log <- capture.output(
       fit <- modelSelection(
-        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE,
+        y=y6, x=X6, priorCoef=pCoef, priorDelta=pDelta, enumerate=FALSE, XtXprecomp=FALSE,
         family=family, priorSkew=pCoef, priorGroup=pGroup, groups=groups
       )
     )

--- a/tests/testthat/test-modelSelection-gibbs.R
+++ b/tests/testthat/test-modelSelection-gibbs.R
@@ -82,7 +82,8 @@ patrick::with_parameters_test_that(
     expect_true("3,4,6,7" %in% pprobs$modelid[1:4])
   },
   patrick::cases(
-    normid_gzell=list(family="normal", pCoef=normalidprior(tau=0.348), pGroup=groupzellnerprior(tau=0.4))
+    normid_gzell=list(family="normal", pCoef=normalidprior(tau=0.348), pGroup=groupzellnerprior(tau=0.4)),
+    zell_gzell=list(family="normal", pCoef=zellnerprior(tau=0.348), pGroup=groupzellnerprior(tau=0.4))
   )
 )
 

--- a/tests/testthat/test-nlpMarginal-groups.R
+++ b/tests/testthat/test-nlpMarginal-groups.R
@@ -65,11 +65,11 @@ patrick::with_parameters_test_that(
       seq_along(theta9_truth), y9, X9, groups=groups, family="normal",
       priorCoef=pCoef, priorGroup=pGroup, priorVar=pVar
     )
-    expect_true(ans_max > ans_all)
     expect_equal(ans_max, expected_max, tolerance=tolerance)
     expect_equal(ans_all, expected_all, tolerance=tolerance)
   },
   patrick::cases(
-    normid_gzell=list(pCoef=normalidprior(tau=0.3), pGroup=groupzellnerprior(tau=0.4), expected_max=-305.4831201, expected_all=-307.8938408)
+    normid_gzell=list(pCoef=normalidprior(tau=0.3), pGroup=groupzellnerprior(tau=0.4), expected_max=-305.4831201, expected_all=-307.8938408),
+    zell_gzell=list(pCoef=zellnerprior(tau=0.3), pGroup=groupzellnerprior(tau=0.4), expected_max=-335.9330409, expected_all=-335.6280634)
   )
 )

--- a/tests/testthat/test-nlpMarginal-groups.R
+++ b/tests/testthat/test-nlpMarginal-groups.R
@@ -2,7 +2,7 @@ context("Test nlpMarginal with groups")
 library("mombf")
 
 source(test_path("data-for-tests.R"))
-tolerance <- 1e-5
+tolerance <- 1e-6
 
 patrick::with_parameters_test_that(
   "check_sel_groups works", {
@@ -50,4 +50,26 @@ patrick::with_parameters_test_that(
   },
   test_name=c("mom", "imom", "emom", "zellner", "normalid"),
   pCoef=c(momprior(tau=0.35), imomprior(tau=0.35), emomprior(tau=0.35), zellnerprior(tau=0.35), normalidprior(tau=0.35))
+)
+
+patrick::with_parameters_test_that(
+  "nlpMarginal with groups is correctly impemented for normal family:", {
+    pVar <- igprior(alpha=0.01, lambda=0.01)
+    groups <- c(1,2,3,4,5,5,5,6,6,6)
+    ans_max <- nlpMarginal(
+      theta9_truth_idx, y9, X9, groups=groups, family="normal",
+      priorCoef=pCoef, priorGroup=pGroup, priorVar=pVar
+    )
+
+    ans_all <- nlpMarginal(
+      seq_along(theta9_truth), y9, X9, groups=groups, family="normal",
+      priorCoef=pCoef, priorGroup=pGroup, priorVar=pVar
+    )
+    expect_true(ans_max > ans_all)
+    expect_equal(ans_max, expected_max, tolerance=tolerance)
+    expect_equal(ans_all, expected_all, tolerance=tolerance)
+  },
+  patrick::cases(
+    normid_gzell=list(pCoef=normalidprior(tau=0.3), pGroup=groupzellnerprior(tau=0.4), expected_max=-305.4831201, expected_all=-307.8938408)
+  )
 )


### PR DESCRIPTION
Adds `normidgzellMarg` and `zellgzellMarg` with tests for their precision using `nlpMarginal` and tests for proper usage of covariance sparce matrix using `modelSelection`.

Also makes some changes on `crossprodmat`.

The correct implementation of these two marginal functions can be found in another repository: [check_solution_normid_gzell.R](https://github.com/OriolAbril/R-experiments/blob/master/normal_ig_analytical/check_solution_normid_gzell.R) and [check_solution_zell_gzell.R](https://github.com/OriolAbril/R-experiments/blob/master/normal_ig_analytical/check_solution_zell_gzell.R).