### PR TITLE
Replace deprecated use of `test_name`.

### DIFF
--- a/tests/testthat/test-modelSelection-enum.R
+++ b/tests/testthat/test-modelSelection-enum.R
@@ -79,7 +79,7 @@ patrick::with_parameters_test_that(
     pprobs <- postProb(fit)
     expect_true(any(pprobs$modelid[1:5] == "3,4,6,7"))
   },
-  test_name=c("uniform", "binomial", "betabinomial", "complex"),
+  .test_name=c("uniform", "binomial", "betabinomial", "complex"),
   pDelta=c(modelunifprior(), modelbinomprior(p=0.5), modelbbprior(alpha.p=1, beta.p=1), modelcomplexprior(c=1))
 )
 

--- a/tests/testthat/test-msfit-methods.R
+++ b/tests/testthat/test-msfit-methods.R
@@ -41,5 +41,5 @@ patrick::with_parameters_test_that(
     expect_equal(pprobs[1:5,3], pprobs_cut[,3], tolerance=tolerance)
   },
   method=c("norm", "exact"),
-  test_name=method
+  .test_name=method
 )

--- a/tests/testthat/test-mspriorspec.R
+++ b/tests/testthat/test-mspriorspec.R
@@ -12,6 +12,6 @@ patrick::with_parameters_test_that(
     expect_equal(as.double(pr_taustd@priorPars['taustd']), 2)
     expect_equal(as.double(pr_tau@priorPars['tau']), .3)
   },
-  test_name=c("momprior", "zellnerprior", "normalidprior", "groupmomprior", "groupzellnerprior"),
+  .test_name=c("momprior", "zellnerprior", "normalidprior", "groupmomprior", "groupzellnerprior"),
   priorfun=c(momprior, zellnerprior, normalidprior, groupmomprior, groupzellnerprior)
 )

--- a/tests/testthat/test-nlpMarginal-groups.R
+++ b/tests/testthat/test-nlpMarginal-groups.R
@@ -47,7 +47,7 @@ patrick::with_parameters_test_that(
     expect_equal(ans_max, ans_max_group)
     expect_equal(ans_all, ans_all_group)
   },
-  test_name=c("mom", "imom", "emom", "zellner", "normalid"),
+  .test_name=c("mom", "imom", "emom", "zellner", "normalid"),
   pCoef=c(momprior(tau=0.35), imomprior(tau=0.35), emomprior(tau=0.35), zellnerprior(tau=0.35), normalidprior(tau=0.35))
 )
 


### PR DESCRIPTION
We have a `.test_name` instead, and the old option is getting removed. Using a dot prefix is a common TV design principle.

https://design.tidyverse.org/dots-prefix.html

Fixes #27 